### PR TITLE
デザイン変更

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,7 +4,6 @@ const path = require('path')
 const createPaginatedPages = require("gatsby-paginate");
 const dayjs = require('dayjs')
 const h2p = require('html2plaintext')
-const visit = require('unist-util-visit')
 
 const Parser = require('rss-parser')
 const parser = new Parser()
@@ -68,24 +67,7 @@ exports.onCreateNode = ({ node, actions, createNodeId }) => {
     const dateNode = buildDateNode({ nodeId: node.id, day, createNodeId })
     createNode(dateNode)
     createParentChildLink({parent: node, child: dateNode})
-  } else if (node.internal.type === 'MarkdownRemark') {
-    // console.log(node)
-    // visit(node.htmlAst, 'image', (node) => {
-    //   console.log(JSON.stringify(node, null , 4))
-
-    // })
   }
-}
-
-exports.setFieldsOnGraphQLNodeType = (
-  { type, store, pathPrefix, getNode, getNodesByType, cache, reporter },
-  pluginOptions
-) => {
-  if (type.name !== `MarkdownRemark`) {
-    return {}
-  }
-
-  // console.log(JSON.stringify(type, null ,4))
 }
 
 exports.createPages = require('./gatsby/createPages')

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,6 +4,7 @@ const path = require('path')
 const createPaginatedPages = require("gatsby-paginate");
 const dayjs = require('dayjs')
 const h2p = require('html2plaintext')
+const visit = require('unist-util-visit')
 
 const Parser = require('rss-parser')
 const parser = new Parser()
@@ -67,7 +68,24 @@ exports.onCreateNode = ({ node, actions, createNodeId }) => {
     const dateNode = buildDateNode({ nodeId: node.id, day, createNodeId })
     createNode(dateNode)
     createParentChildLink({parent: node, child: dateNode})
+  } else if (node.internal.type === 'MarkdownRemark') {
+    // console.log(node)
+    // visit(node.htmlAst, 'image', (node) => {
+    //   console.log(JSON.stringify(node, null , 4))
+
+    // })
   }
+}
+
+exports.setFieldsOnGraphQLNodeType = (
+  { type, store, pathPrefix, getNode, getNodesByType, cache, reporter },
+  pluginOptions
+) => {
+  if (type.name !== `MarkdownRemark`) {
+    return {}
+  }
+
+  // console.log(JSON.stringify(type, null ,4))
 }
 
 exports.createPages = require('./gatsby/createPages')

--- a/src/components/PostCell.tsx
+++ b/src/components/PostCell.tsx
@@ -15,6 +15,9 @@ const Cell = styled.div`
     padding-left: 0;
     padding-right: 0;
   }
+  &:hover .title {
+    color: #4d9abf;
+  }
 `
 
 const Category = styled.div`
@@ -129,6 +132,7 @@ const PostCell: React.SFC<Props> = ({ post, style }) => {
             {postNode.relative_category || 'blog'}
           </Category>
           <PostTitle
+            className="title"
             dangerouslySetInnerHTML={{ __html: postNode.fields.title }}
           />
           <PostDescription>

--- a/src/components/PostCell.tsx
+++ b/src/components/PostCell.tsx
@@ -91,7 +91,7 @@ const PostLink = ({ node, children, style }: any) => {
 
 interface Props {
   post: any
-  style: any
+  style?: any
 }
 
 const PostCell: React.SFC<Props> = ({ post, style = {} }) => {

--- a/src/components/PostCell.tsx
+++ b/src/components/PostCell.tsx
@@ -7,18 +7,11 @@ import { Category } from '../templates/post'
 
 const Cell = styled.div`
   height: 100%;
-  border: 1px solid #eee;
   background-color: white;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   border-radius: 8px;
-  transform: translateY(0);
-  transition: transform 0.15s ease-in, box-shadow 0.15s ease-in;
   display: flex;
   flex-direction: column;
-  &:hover {
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.16);
-    transform: translateY(-4px);
-  }
+  border-bottom: 1px solid #eee;
 `
 
 const CellContent = styled.div`
@@ -46,8 +39,8 @@ const PostDescription = styled.p`
 `
 
 const CellFooter = styled.div`
-  border-top: 1px solid #eee;
-  padding: 9px 20px 12px;
+  /* border-top: 1px solid #eee; */
+  padding: 0 20px 20px;
   margin-top: auto;
 `
 
@@ -101,11 +94,15 @@ interface Props {
   style: any
 }
 
-const PostCell : React.SFC<Props> = ({ post, style = {} }) => {
+const PostCell: React.SFC<Props> = ({ post, style = {} }) => {
   const postNode: any = post
 
   return (
-    <PostLink style={style} node={postNode} key={postNode.number || postNode.link}>
+    <PostLink
+      style={style}
+      node={postNode}
+      key={postNode.number || postNode.link}
+    >
       <Cell>
         <CellContent>
           <Category type={postNode.link ? 'note' : 'blog'}>

--- a/src/components/PostCell.tsx
+++ b/src/components/PostCell.tsx
@@ -12,14 +12,11 @@ const Cell = styled.div`
   display: flex;
   flex-direction: column;
   border-bottom: 1px solid #eee;
+  padding: 20px 0;
 `
 
 const CellContent = styled.div`
-  padding: 20px 12px 12px;
-  @media (min-width: 600px) {
-    padding-left: 20px;
-    padding-right: 20px;
-  }
+  margin-bottom: 8px;
 `
 
 const PostTitle = styled.h3`
@@ -40,7 +37,6 @@ const PostDescription = styled.p`
 
 const CellFooter = styled.div`
   /* border-top: 1px solid #eee; */
-  padding: 0 20px 20px;
   margin-top: auto;
 `
 

--- a/src/components/PostCell.tsx
+++ b/src/components/PostCell.tsx
@@ -94,7 +94,7 @@ interface Props {
   style?: any
 }
 
-const PostCell: React.SFC<Props> = ({ post, style = {} }) => {
+const PostCell: React.SFC<Props> = ({ post, style }) => {
   const postNode: any = post
 
   return (

--- a/src/components/PostCell.tsx
+++ b/src/components/PostCell.tsx
@@ -12,7 +12,11 @@ const Cell = styled.div`
   display: flex;
   flex-direction: column;
   border-bottom: 1px solid #eee;
-  padding: 20px 0;
+  padding: 20px 12px;
+  @media (min-width: 624px) {
+    padding-left: 0;
+    padding-right: 0;
+  }
 `
 
 const CellContent = styled.div`

--- a/src/components/PostCell.tsx
+++ b/src/components/PostCell.tsx
@@ -3,8 +3,6 @@ import { Link } from 'gatsby'
 import React from 'react'
 import styled from 'styled-components'
 
-import { Category } from '../templates/post'
-
 const Cell = styled.div`
   height: 100%;
   background-color: white;
@@ -19,12 +17,34 @@ const Cell = styled.div`
   }
 `
 
+const Category = styled.div`
+  background-color: white;
+  font-weight: 600;
+  display: inline-block;
+  font-size: 12px;
+  background-image: linear-gradient(
+    45deg,
+    rgb(77, 154, 191) 0px,
+    rgb(0, 162, 199) 100%
+  );
+  color: white;
+  text-transform: capitalize;
+  letter-spacing: 0.2px;
+  border-style: solid;
+  border-color: rgb(221, 221, 221);
+  border-image: initial;
+  margin: 0px 8px 4px 0px;
+  padding: 4px 6px;
+  border-radius: 3px;
+  border-width: 0px;
+`
+
 const CellContent = styled.div`
   margin-bottom: 8px;
 `
 
 const PostTitle = styled.h3`
-  margin-bottom: 4px;
+  margin-bottom: 1px;
   font-size: 18px;
   line-height: 1.48;
   color: #222;

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const Profile = () => {
+  return (
+    <Base>
+      <div className="heading">
+        <img
+          className="avatar"
+          src="https://img.esa.io/uploads/production/teams/6967/icon/thumb_ms_fec180ecca810585b0ad19eb60c24fcc.jpg"
+        />
+        <div className="nameArea">
+          <h3 className="name">@mottox2</h3>
+          <p className="role">WEBエンジニア</p>
+        </div>
+      </div>
+      <div className="description">
+        都内でフリーランスエンジニア・デザイナーとしてWebサービスやスマホアプリを作っています。
+        <br />
+        新規事業の爆速立ち上げや、使いやすいSPAの開発が得意です。
+      </div>
+    </Base>
+  )
+}
+
+const Base = styled.div`
+  > .heading {
+    display: flex;
+    align-items: center;
+    > .avatar {
+      height: 42px;
+      width: 42px;
+      margin-right: 8px;
+      border-radius: 21px;
+    }
+
+    > .nameArea {
+      > .name {
+        font-size: 16px;
+        color: #30627a;
+        letter-spacing: 0.5px;
+      }
+
+      > .role {
+        margin-top: 1px;
+        font-size: 12px;
+        letter-spacing: 0.5px;
+      }
+    }
+  }
+
+  > .description {
+    font-size: 12px;
+    color: rgba(0, 0, 0, 0.8);
+    margin-top: 8px;
+    line-height: 1.7;
+  }
+`
+
+export default Profile

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -8,6 +8,7 @@ const Profile = () => {
         <img
           className="avatar"
           src="https://img.esa.io/uploads/production/teams/6967/icon/thumb_ms_fec180ecca810585b0ad19eb60c24fcc.jpg"
+          alt="mottox2"
         />
         <div className="nameArea">
           <h3 className="name">@mottox2</h3>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 import Profile from './Profile'
+import Tag from './Tag'
 
 const Sidebar = () => {
   return (
@@ -19,24 +20,6 @@ const Sidebar = () => {
     </Base>
   )
 }
-
-const Tag = styled(Link)`
-  display: inline-block;
-  background-color: #eee;
-  color: rgba(0, 0, 0, 0.6);
-  padding: 6px 12px;
-  margin-right: 8px;
-  font-weight: bold;
-  font-size: 12px;
-  border-radius: 4px;
-  text-decoration: none;
-  &:hover {
-    background-color: #ddd;
-  }
-  &:before {
-    content: "#";
-  }
-`
 
 const Base = styled.aside`
   min-width: 320px;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -40,11 +40,16 @@ const Tag = styled(Link)`
 
 const Base = styled.aside`
   min-width: 320px;
-  width: 320px;
-  margin-left: 20px;
-  padding: 32px 20px;
+  padding: 32px 12px;
   background-color: #f8f8f8;
-  border-left: 1px #eee solid;
+
+  @media (min-width: 980px) {
+    width: 320px;
+    padding-left: 20px;
+    padding-right: 20px;
+    margin-left: 20px;
+    border-left: 1px #eee solid;
+  }
 `
 
 const SideSection = styled.div`

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,62 @@
+import { Link } from 'gatsby'
+import React from 'react'
+import styled from 'styled-components'
+
+import Profile from './Profile'
+
+const Sidebar = () => {
+  return (
+    <Base>
+      <SideSectionTitle>PROFILE</SideSectionTitle>
+      <SideSection>
+        <Profile />
+      </SideSection>
+      <SideSectionTitle>PICKUP TAGS</SideSectionTitle>
+      <SideSection>
+        <Tag to="/tags/gatsby">gatsby</Tag>
+        <Tag to="/tags/netlify">netlify</Tag>
+      </SideSection>
+    </Base>
+  )
+}
+
+const Tag = styled(Link)`
+  display: inline-block;
+  background-color: #eee;
+  color: rgba(0, 0, 0, 0.6);
+  padding: 6px 12px;
+  margin-right: 8px;
+  font-weight: bold;
+  font-size: 12px;
+  border-radius: 4px;
+  text-decoration: none;
+  &:hover {
+    background-color: #ddd;
+  }
+  &:before {
+    content: "#";
+  }
+`
+
+const Base = styled.aside`
+  min-width: 320px;
+  width: 320px;
+  margin-left: 20px;
+  padding: 32px 20px;
+  background-color: #f8f8f8;
+  border-left: 1px #eee solid;
+`
+
+const SideSection = styled.div`
+  margin: 12px 0 24px;
+`
+
+const SideSectionTitle = styled.h2`
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 8px;
+  letter-spacing: 1px;
+  color: #30627a;
+`
+
+export default Sidebar

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'gatsby'
+import styled from 'styled-components'
+
+export default styled(Link)`
+  display: inline-block;
+  background-color: white;
+  border: 1px solid #eee;
+  color: rgba(0, 0, 0, 0.6);
+  padding: 6px 12px;
+  margin-right: 8px;
+  font-weight: bold;
+  font-size: 12px;
+  border-radius: 4px;
+  text-decoration: none;
+  &:hover {
+    border-color: #ccc;
+    color: rgba(0, 0, 0, 0.8);
+  }
+  &:before {
+    content: "#";
+  }
+`

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -8,7 +8,9 @@ import AuthorProfile from '../components/AuthorProfile'
 import Content from '../components/Content'
 import Layout from '../components/Layout'
 import PostCell from '../components/PostCell'
+import Sidebar from '../components/Sidebar'
 import SocialLinks from '../components/SocialLinks'
+import { Container, MainColumn } from './posts'
 
 export const Wrapper = styled.div`
   padding: 12px;
@@ -82,48 +84,56 @@ const PostTemplate = (props: any) => {
 
   return (
     <Layout location={props.location}>
-      <Wrapper>
-        <Helmet title={`${title} - mottox2 blog`}>
-          <meta name="description" content={description} />
+      <Helmet title={`${title} - mottox2 blog`}>
+        <meta name="description" content={description} />
 
-          <meta property="og:url" content={url} />
-          <meta property="og:type" content="article" />
-          <meta property="og:title" content={title} />
-          <meta property="og:description" content={description} />
-          <meta property="og:image" content={image} />
-          {/* <meta property="fb:app_id" content={config.siteFBAppID ? config.siteFBAppID : ''} /> */}
+        <meta property="og:url" content={url} />
+        <meta property="og:type" content="article" />
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:image" content={image} />
+        {/* <meta property="fb:app_id" content={config.siteFBAppID ? config.siteFBAppID : ''} /> */}
 
-          {/* Twitter Card tags */}
-          <meta name="twitter:card" content="summary" />
-          <meta name="twitter:creator" content={'@mottox2'} />
-          <meta name="twitter:title" content={title} />
-          <meta name="twitter:description" content={description} />
-          <meta name="twitter:image" content={image} />
+        {/* Twitter Card tags */}
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:creator" content={'@mottox2'} />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={image} />
 
-          <link rel="canonical" href={url} />
-        </Helmet>
+        <link rel="canonical" href={url} />
+      </Helmet>
 
-        <Link to={`/categories/${category}`}>
-          <Category>{category}</Category>
-        </Link>
-        {/* </Link> */}
-        <Title dangerouslySetInnerHTML={{ __html: title }} />
-        {post.tags.map((tag: any) => (
-          <Link to={`/tags/${tag}`} key={tag}>
-            <Tag>{tag}</Tag>
+      <Container>
+        <MainColumn>
+          <Link to={`/categories/${category}`}>
+            <Category>{category}</Category>
           </Link>
-        ))}
-        <Author post={post} />
-        <Content dangerouslySetInnerHTML={{ __html: post.body_html }} />
-        <AuthorProfile />
-        <SocialLinkWrapper>
-          <SocialLinks title={title} url={url} />
-        </SocialLinkWrapper>
-        { latestPosts.map(postEdge => {
-          const post = postEdge.node
-          return <PostCell key={post.number} style={{ margin: '12px 0' }} post={post}/>
-        })}
-      </Wrapper>
+          <Title dangerouslySetInnerHTML={{ __html: title }} />
+          {post.tags.map((tag: any) => (
+            <Link to={`/tags/${tag}`} key={tag}>
+              <Tag>{tag}</Tag>
+            </Link>
+          ))}
+          <Author post={post} />
+          <Content dangerouslySetInnerHTML={{ __html: post.body_html }} />
+          <AuthorProfile />
+          <SocialLinkWrapper>
+            <SocialLinks title={title} url={url} />
+          </SocialLinkWrapper>
+          {latestPosts.map(postEdge => {
+            const postNode = postEdge.node
+            return (
+              <PostCell
+                key={postNode.number}
+                style={{ margin: '12px 0' }}
+                post={postNode}
+              />
+            )
+          })}
+        </MainColumn>
+        <Sidebar />
+      </Container>
     </Layout>
   )
 }

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -106,21 +106,23 @@ const PostTemplate = (props: any) => {
 
       <Container>
         <MainColumn style={{ marginTop: 32 }}>
-          <Link to={`/categories/${category}`}>
-            <Category>{category}</Category>
-          </Link>
-          <Title dangerouslySetInnerHTML={{ __html: title }} />
-          {post.tags.map((tag: any) => (
-            <Link to={`/tags/${tag}`} key={tag}>
-              <Tag>{tag}</Tag>
+          <Padding>
+            <Link to={`/categories/${category}`}>
+              <Category>{category}</Category>
             </Link>
-          ))}
-          <Author post={post} />
-          <Content dangerouslySetInnerHTML={{ __html: post.body_html }} />
-          <AuthorProfile />
-          <SocialLinkWrapper>
-            <SocialLinks title={title} url={url} />
-          </SocialLinkWrapper>
+            <Title dangerouslySetInnerHTML={{ __html: title }} />
+            {post.tags.map((tag: any) => (
+              <Link to={`/tags/${tag}`} key={tag}>
+                <Tag>{tag}</Tag>
+              </Link>
+            ))}
+            <Author post={post} />
+            <Content dangerouslySetInnerHTML={{ __html: post.body_html }} />
+            <AuthorProfile />
+            <SocialLinkWrapper>
+              <SocialLinks title={title} url={url} />
+            </SocialLinkWrapper>
+          </Padding>
           {latestPosts.map(postEdge => {
             const postNode = postEdge.node
             return (
@@ -139,6 +141,13 @@ const PostTemplate = (props: any) => {
 }
 
 export default PostTemplate
+
+const Padding = styled.div`
+  padding: 0 12px;
+  @media (min-width: 980px) {
+    padding: 0;
+  }
+`
 
 export const pageQuery = graphql`
   query BlogPostBySlug($number: Int!) {

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -10,6 +10,7 @@ import Layout from '../components/Layout'
 import PostCell from '../components/PostCell'
 import Sidebar from '../components/Sidebar'
 import SocialLinks from '../components/SocialLinks'
+import Tag from '../components/Tag'
 import { Container, MainColumn } from './posts'
 
 export const Wrapper = styled.div`
@@ -32,36 +33,22 @@ const Title = styled.h1`
   }
 `
 
-const Tag = styled<
-  {
-    type?: string;
-  },
-  'div'
->('div')`
-  background-color: white;
-  font-weight: 600;
-  color: rgba(0, 0, 0, 0.58);
-  display: inline-block;
-  padding: 6px 16px;
-  border: 1px solid #ddd;
-  font-size: 12px;
-  margin: 4px 8px 4px 0;
-  border-radius: 20px;
-`
-
-export const Category = Tag.extend`
+const Category = Tag.extend`
   background-image: ${props =>
     props.type === 'note'
       ? 'linear-gradient(45deg,#41C9B4 0,#41C9B4 100%)'
       : 'linear-gradient(45deg,#4d9abf 0,#00a2c7 100%)'};
   color: white;
-  padding: 4px 6px;
-  border-radius: 3px;
-  border-width: 0;
-  margin-top: 0;
   margin-bottom: 4px;
   text-transform: capitalize;
   letter-spacing: 0.2px;
+  &:hover {
+    border-color: inherit;
+    color: white;
+  }
+  &:before {
+    content: "";
+  }
 `
 
 const SocialLinkWrapper = styled.div`
@@ -107,14 +94,16 @@ const PostTemplate = (props: any) => {
       <Container>
         <MainColumn style={{ marginTop: 32 }}>
           <Padding>
-            <Link to={`/categories/${category}`}>
-              <Category>{category}</Category>
-            </Link>
+            <Category to={`/categories/${category}`}>{category}</Category>
             <Title dangerouslySetInnerHTML={{ __html: title }} />
             {post.tags.map((tag: any) => (
-              <Link to={`/tags/${tag}`} key={tag}>
-                <Tag>{tag}</Tag>
-              </Link>
+              <Tag
+                to={`/tags/${tag}`}
+                key={tag}
+                style={{ marginTop: 4, marginBottom: 8 }}
+              >
+                {tag}
+              </Tag>
             ))}
             <Author post={post} />
             <Content dangerouslySetInnerHTML={{ __html: post.body_html }} />
@@ -123,7 +112,7 @@ const PostTemplate = (props: any) => {
               <SocialLinks title={title} url={url} />
             </SocialLinkWrapper>
           </Padding>
-          {latestPosts.map(postEdge => {
+          {latestPosts.map((postEdge: any) => {
             const postNode = postEdge.node
             return <PostCell key={postNode.number} post={postNode} />
           })}

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -125,13 +125,7 @@ const PostTemplate = (props: any) => {
           </Padding>
           {latestPosts.map(postEdge => {
             const postNode = postEdge.node
-            return (
-              <PostCell
-                key={postNode.number}
-                style={{ margin: '12px 0' }}
-                post={postNode}
-              />
-            )
+            return <PostCell key={postNode.number} post={postNode} />
           })}
         </MainColumn>
         <Sidebar />

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -105,7 +105,7 @@ const PostTemplate = (props: any) => {
       </Helmet>
 
       <Container>
-        <MainColumn>
+        <MainColumn style={{ marginTop: 32 }}>
           <Link to={`/categories/${category}`}>
             <Category>{category}</Category>
           </Link>

--- a/src/templates/posts.tsx
+++ b/src/templates/posts.tsx
@@ -31,11 +31,9 @@ const IndexPage = ({ pageContext, location }: any) => {
               <small>に関する記事</small>
             </Title>
           )}
-          {/* <Grid> */}
           {group.map(({ node }: any) => (
             <PostCell key={node.number || node.link} post={node} />
           ))}
-          {/* </Grid> */}
           <Pagination>
             {!first && <Link to={previousUrl}>{'< Previous'}</Link>}
             {!last && (

--- a/src/templates/posts.tsx
+++ b/src/templates/posts.tsx
@@ -49,31 +49,27 @@ const IndexPage = ({ pageContext, location }: any) => {
   )
 }
 
-const ScreenWidth = styled.div`
-  @media (min-width: ${(320 + 24) * 2}px) {
-    max-width: ${(320 + 24) * 2}px;
-  }
-
-  @media (min-width: ${(320 + 24) * 3}px) {
-    max-width: ${(320 + 24) * 3}px;
-  }
-`
-
 export const Container = styled.div`
   /* max-width: 980px; */
   /* margin: 0 auto; */
   display: flex;
+  flex-direction: column;
+
+  @media (min-width: 980px) {
+    flex-direction: row;
+  }
 `
 
 export const MainColumn = styled.div`
   max-width: 600px;
+  width: 100%;
   margin: 20px auto;
 `
 
-const Pagination = ScreenWidth.extend`
+const Pagination = styled.div`
   display: flex;
-  margin: 16px auto 32px;
-  padding: 0 12px;
+  width: 100%;
+  margin: 24px 0;
 `
 
 const Title = styled.h1`

--- a/src/templates/posts.tsx
+++ b/src/templates/posts.tsx
@@ -70,6 +70,7 @@ const Pagination = styled.div`
   display: flex;
   width: 100%;
   margin: 24px 0;
+  padding: 0 12px;
 `
 
 const Title = styled.h1`

--- a/src/templates/posts.tsx
+++ b/src/templates/posts.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import Layout from '../components/Layout'
 import PostCell from '../components/PostCell'
+import Profile from '../components/Profile'
 
 const IndexPage = ({ pageContext, location }: any) => {
   const { group, index, first, last, additionalContext } = pageContext
@@ -14,36 +15,87 @@ const IndexPage = ({ pageContext, location }: any) => {
 
   return (
     <Layout location={location}>
+      <Helmet title={`mottox2 blog`}>
+        <meta
+          name="description"
+          content={
+            'mottox2のエンジニア・デザインブログ。RailsとかReactとかTypeScriptとかを中心に書いています。'
+          }
+        />
+      </Helmet>
       <Container>
-        <Helmet title={`mottox2 blog`}>
-          <meta
-            name="description"
-            content={
-              'mottox2のエンジニア・デザインブログ。RailsとかReactとかTypeScriptとかを中心に書いています。'
-            }
-          />
-        </Helmet>
-        {(tag || category) && (
-          <Title>
-            {tag || category}
-            <small>に関する記事</small>
-          </Title>
-        )}
-        <Grid>
-          {group.map(({ node }: any) => <PostCell key={node.number || node.link} post={node} />)}
-        </Grid>
-        <Pagination>
-          {!first && <Link to={previousUrl}>{'< Previous'}</Link>}
-          {!last && (
-            <Link style={{ marginLeft: 'auto' }} to={nextUrl}>
-              {'Next >'}
-            </Link>
+        <div style={{ flex: 1 }}>
+          {(tag || category) && (
+            <Title>
+              {tag || category}
+              <small>に関する記事</small>
+            </Title>
           )}
-        </Pagination>
+          {/* <Grid> */}
+          {group.map(({ node }: any) => (
+            <PostCell key={node.number || node.link} post={node} />
+          ))}
+          {/* </Grid> */}
+          <Pagination>
+            {!first && <Link to={previousUrl}>{'< Previous'}</Link>}
+            {!last && (
+              <Link style={{ marginLeft: 'auto' }} to={nextUrl}>
+                {'Next >'}
+              </Link>
+            )}
+          </Pagination>
+        </div>
+        <Sidebar>
+          <SideSectionTitle>PROFILE</SideSectionTitle>
+          <SideSection>
+            <Profile />
+          </SideSection>
+          <SideSectionTitle>PICKUP TAGS</SideSectionTitle>
+          <SideSection>
+            <Tag to="/tags/gatsby">gatsby</Tag>
+            <Tag to="/tags/netlify">netlify</Tag>
+          </SideSection>
+        </Sidebar>
       </Container>
     </Layout>
   )
 }
+
+const Tag = styled(Link)`
+  display: inline-block;
+  background-color: #eee;
+  color: rgba(0, 0, 0, 0.6);
+  padding: 6px 12px;
+  margin-right: 8px;
+  font-weight: bold;
+  font-size: 12px;
+  border-radius: 4px;
+  text-decoration: none;
+  &:hover {
+    background-color: #ddd;
+  }
+  &:before {
+    content: "#";
+  }
+`
+
+const Sidebar = styled.aside`
+  min-width: 300px;
+  width: 300px;
+  margin-left: 40px;
+`
+
+const SideSection = styled.div`
+  margin: 12px 0 24px;
+`
+
+const SideSectionTitle = styled.h2`
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 8px;
+  letter-spacing: 1px;
+  color: #30627a;
+`
 
 const ScreenWidth = styled.div`
   @media (min-width: ${(320 + 24) * 2}px) {
@@ -56,7 +108,10 @@ const ScreenWidth = styled.div`
 `
 
 const Container = styled.div`
+  max-width: 980px;
+  margin: 0 auto;
   margin-top: 12px;
+  display: flex;
   @media screen and (min-width: 600px) {
     margin-top: 24px;
   }

--- a/src/templates/posts.tsx
+++ b/src/templates/posts.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 
 import Layout from '../components/Layout'
 import PostCell from '../components/PostCell'
-import Profile from '../components/Profile'
+import Sidebar from '../components/Sidebar'
 
 const IndexPage = ({ pageContext, location }: any) => {
   const { group, index, first, last, additionalContext } = pageContext
@@ -24,7 +24,7 @@ const IndexPage = ({ pageContext, location }: any) => {
         />
       </Helmet>
       <Container>
-        <div style={{ flex: 1 }}>
+        <MainColumn>
           {(tag || category) && (
             <Title>
               {tag || category}
@@ -44,58 +44,12 @@ const IndexPage = ({ pageContext, location }: any) => {
               </Link>
             )}
           </Pagination>
-        </div>
-        <Sidebar>
-          <SideSectionTitle>PROFILE</SideSectionTitle>
-          <SideSection>
-            <Profile />
-          </SideSection>
-          <SideSectionTitle>PICKUP TAGS</SideSectionTitle>
-          <SideSection>
-            <Tag to="/tags/gatsby">gatsby</Tag>
-            <Tag to="/tags/netlify">netlify</Tag>
-          </SideSection>
-        </Sidebar>
+        </MainColumn>
+        <Sidebar />
       </Container>
     </Layout>
   )
 }
-
-const Tag = styled(Link)`
-  display: inline-block;
-  background-color: #eee;
-  color: rgba(0, 0, 0, 0.6);
-  padding: 6px 12px;
-  margin-right: 8px;
-  font-weight: bold;
-  font-size: 12px;
-  border-radius: 4px;
-  text-decoration: none;
-  &:hover {
-    background-color: #ddd;
-  }
-  &:before {
-    content: "#";
-  }
-`
-
-const Sidebar = styled.aside`
-  min-width: 300px;
-  width: 300px;
-  margin-left: 40px;
-`
-
-const SideSection = styled.div`
-  margin: 12px 0 24px;
-`
-
-const SideSectionTitle = styled.h2`
-  font-size: 16px;
-  font-weight: bold;
-  margin-bottom: 8px;
-  letter-spacing: 1px;
-  color: #30627a;
-`
 
 const ScreenWidth = styled.div`
   @media (min-width: ${(320 + 24) * 2}px) {
@@ -107,48 +61,21 @@ const ScreenWidth = styled.div`
   }
 `
 
-const Container = styled.div`
-  max-width: 980px;
-  margin: 0 auto;
-  margin-top: 12px;
+export const Container = styled.div`
+  /* max-width: 980px; */
+  /* margin: 0 auto; */
   display: flex;
-  @media screen and (min-width: 600px) {
-    margin-top: 24px;
-  }
+`
+
+export const MainColumn = styled.div`
+  max-width: 600px;
+  margin: 20px auto;
 `
 
 const Pagination = ScreenWidth.extend`
   display: flex;
   margin: 16px auto 32px;
   padding: 0 12px;
-`
-
-const Grid = ScreenWidth.extend`
-  margin: 0 auto;
-  max-width: 100%;
-
-  display: flex;
-  flex-wrap: wrap;
-  column-count: 3;
-  column-gap: 0;
-
-  > * {
-    display: inline-block;
-    margin: 0 12px;
-    vertical-align: top;
-    width: 100%;
-    margin-bottom: 12px;
-
-    /* max-widthのあれ */
-    @media (min-width: ${(320 + 24) * 2}px) {
-      width: 320px;
-      margin-bottom: 20px;
-    }
-
-    @media (min-width: ${(320 + 24) * 3}px) {
-      width: 320px;
-    }
-  }
 `
 
 const Title = styled.h1`


### PR DESCRIPTION
## なぜやるか
* Gatsbyの普及を進めていく上でより現実世界のサイトに近づけたい。そこで2カラムな感じにした。
* より呼んでほしい記事への動線を強くしたい。回遊率も上がると嬉しい。
* サポーターズでのハンズオンや本の宣伝スペースがあると嬉しい。
* サムネがなくても違和感のないデザインにしたい。

## スクショ
![localhost_8000_](https://user-images.githubusercontent.com/7007253/50403358-55cc5000-07e1-11e9-9589-965e966a5176.png)
